### PR TITLE
docs: add .github/copilot-instructions.md for Copilot agent context

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -57,21 +57,28 @@ printf 'expected output' | sha256sum
 Use the `hex!()` macro from `hex-literal`:
 
 ```rust
-expected_sha256: &hex!("abcdef...32 hex chars..."),
+expected_sha256: &hex!("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
 ```
+
+SHA-256 produces 32 bytes = **64 hexadecimal characters**.
 
 ---
 
 ## Platform guards
 
+CI currently runs on Linux only.  The harness is POSIX-only and
+will not compile on Windows.  macOS is welcome for local development
+but is not in the CI matrix.
+
 | Feature | Guard |
 |---------|-------|
 | Round-trip harness tests | `#[cfg(unix)]` |
-| Valgrind step | `if: runner.os == 'Linux'` in CI |
-| norminette step | `if: runner.os != 'Windows'` in CI |
-| `detect_leaks=1` in ASAN_OPTIONS | Linux only — LSan is not available on macOS |
+| `detect_leaks=1` in ASAN_OPTIONS | Linux only — LSan not available on macOS |
 
-Never set `ASAN_OPTIONS=detect_leaks=1` unconditionally.
+If a multi-OS CI matrix is ever added:
+- Gate Valgrind with `if: runner.os == 'Linux'`
+- Gate norminette with `if: runner.os != 'Windows'`
+- Do not set `ASAN_OPTIONS=detect_leaks=1` on macOS runners
 
 ---
 


### PR DESCRIPTION
## Summary

Adds `.github/copilot-instructions.md` — the GitHub-supported file
that is injected into every Copilot chat, code-review, and agent
context for this repository.

Content mirrors `CLAUDE.md` but written in Copilot's declarative
instruction format (rules, not shell recipes):

- Config file is `.dawon.toml` (not `.gato.toml`)
- Harness is POSIX-only: `fork()`+`pipe()`, `#[cfg(unix)]` for tests
- SHA-256 commitments: no plaintext expected outputs in generated C
- `detect_leaks=1` in `ASAN_OPTIONS`: Linux only (LSan absent on macOS)
- Commit discipline: CC 1.0.0, atomic commits, DCO `Signed-off-by`
- Adding subjects: strict edge cases (`INT_MIN`, null byte, DEL 127)
- PR discipline: issue-first, rebase merge, all-commits-green rule

Closes #14.

## Test plan

- [ ] Read `.github/copilot-instructions.md` — all sections present
- [ ] Verify no `.gato.toml` references remain
- [ ] No Rust or CI changes; no `cargo test` run required

🤖 Generated with [Claude Code](https://claude.com/claude-code)