### PR TITLE
docs(security): add legal and compliance contact for 42 School

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,6 +33,34 @@ in the release notes unless you prefer anonymity.
 
 ---
 
+## Legal and compliance contact
+
+If you represent 42 School, École 42, or any affiliated entity
+and believe this project infringes on your intellectual property
+or violates your terms of service, **please contact the
+maintainer privately before taking any action**:
+
+```
+https://github.com/qlrd/dawon/security/advisories/new
+```
+
+Use the subject line: `[Legal] <your organisation> — <brief
+description>`.
+
+We are prepared to respond within 48 hours and to remove or
+modify any content immediately upon notification.
+
+### What Dawon does not contain
+
+- No exam subjects, exercise texts, or moulinette source.
+- No expected outputs in plaintext — all test vectors are stored
+  as SHA-256 commitment hashes only.
+- No redistribution of norminette or any 42-internal tool.
+  Norminette is called as an external subprocess that the user
+  must install separately.
+
+---
+
 ## Integrity
 
 Dawon stores expected test outputs as SHA-256 commitment hashes.


### PR DESCRIPTION
## Summary

Adds a **Legal and compliance contact** section to `SECURITY.md`
directing 42 School or any IP holder to the private GitHub
security advisory channel before taking any takedown action.

States clearly what Dawon does **not** contain:

- No exam subjects or exercise texts
- No plaintext expected outputs (SHA-256 hashes only)
- No redistribution of norminette or moulinette

The private advisory goes directly to the maintainer's inbox,
keeping any correspondence off public GitHub issues.

## Motivation

This is the maintainer's first open-source project and a good-faith
attempt to stay within 42's acceptable-use policies.  The section
exists to invite dialogue before any legal action, not as an
admission of wrongdoing.

## Test plan

- [ ] `SECURITY.md` renders correctly on GitHub
- [ ] Private advisory link resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)