### PR TITLE
chore(tests): remove dead fixtures for dropped norminette and forbidden checks

### DIFF
--- a/tests/python/fixtures/forbidden/ft_putchar_printf.c
+++ b/tests/python/fixtures/forbidden/ft_putchar_printf.c
@@ -1,6 +1,0 @@
-#include <stdio.h>
-
-void	ft_putchar(char c)
-{
-	printf("%c", c);
-}

--- a/tests/python/fixtures/norm_error/ft_putchar_norm.c
+++ b/tests/python/fixtures/norm_error/ft_putchar_norm.c
@@ -1,5 +1,0 @@
-#include <unistd.h>
-
-void ft_putchar(char c) {
-    write(1, &c, 1);
-}


### PR DESCRIPTION
## Summary

- Deletes `tests/python/fixtures/forbidden/ft_putchar_printf.c`
- Deletes `tests/python/fixtures/norm_error/ft_putchar_norm.c`

These fixture files became unreferenced after PR #24 dropped the
norminette and forbidden check steps from the eval pipeline. No test
in `test_checks.py` or any Rust integration test references them.

## Test plan

- [ ] `pytest tests/python/` still passes (no references to deleted paths)
- [ ] `cargo test` unaffected

Refs #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)