### PR TITLE
docs(copilot): require --force-with-lease over bare --force

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -116,6 +116,8 @@ If a multi-OS CI matrix is ever added:
   commits — do not bundle a CI fix with unrelated changes)
 - All commits must include `Signed-off-by:` (DCO); Monsieur
   Piscinette signature text is optional for external contributors
+- When force-pushing a branch, always use `--force-with-lease` — never
+  bare `--force`
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `--force-with-lease` requirement to the Commit discipline section
  of copilot-instructions.md
- Mirrors the same rule added to monsieur-ganesha

## Test plan

- [ ] Docs-only change, no tests needed
- [ ] Verify Copilot agent uses `--force-with-lease` in subsequent
  branch updates

Refs qlrd/monsieur-ganesha (same change in companion repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)