### PR TITLE
feat(subjects): add C06 program-based harness and test vectors

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -19,6 +19,12 @@ path = "fuzz_targets/fuzz_forbidden.rs"
 test = false
 doc = false
 
+[[bin]]
+name = "fuzz_c06_compiler"
+path = "fuzz_targets/fuzz_c06_compiler.rs"
+test = false
+doc = false
+
 [dependencies]
 libfuzzer-sys = "0.4"
 dawon = { path = ".." }

--- a/fuzz/fuzz_targets/fuzz_c06_compiler.rs
+++ b/fuzz/fuzz_targets/fuzz_c06_compiler.rs
@@ -1,0 +1,27 @@
+#![no_main]
+
+use std::io::Write as _;
+
+use libfuzzer_sys::fuzz_target;
+
+/// Fuzz the compiler check with arbitrary C source that resembles a
+/// C06 program (i.e. a file that may define `main`).
+///
+/// Invariants:
+/// - `compiler::compile` must never panic on arbitrary input.
+/// - `harness::run_program` must never panic on arbitrary input.
+fuzz_target!(|data: &[u8]| {
+    if let Ok(s) = std::str::from_utf8(data) {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let src = tmp.path().join("ft_fuzz.c");
+        let bin = tmp.path().join("a.out");
+
+        {
+            let mut f = std::fs::File::create(&src).unwrap();
+            let _ = f.write_all(s.as_bytes());
+        }
+
+        // Invariant: compile() must not panic regardless of source content.
+        let _ = dawon::checks::compiler::compile(&[src.as_path()], &bin, false);
+    }
+});

--- a/src/checks/harness.rs
+++ b/src/checks/harness.rs
@@ -32,7 +32,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use crate::report::CheckResult;
-use crate::subjects::{Subject, TestCase};
+use crate::subjects::{ProgramSubject, Subject, TestCase};
 
 // ── C infrastructure injected into every harness ──────────────────
 //
@@ -253,6 +253,94 @@ fn compare_outputs(
         )))
     } else {
         Ok(CheckResult::fail("Function tests", msgs))
+    }
+}
+
+// ── program runner (C06-style: student provides main) ─────────────
+
+/// Compile and run a program-based exercise against all its test cases.
+///
+/// Compiles the student's source files into `./a.out` inside a temp
+/// directory, then invokes it once per `ProgramTestCase` with the
+/// specified `argv` (prepended with `"./a.out"`).  Each run's stdout
+/// is SHA-256 hashed and compared against the stored commitment.
+///
+/// The binary is named `a.out` and invoked via `./a.out` so that
+/// `argv[0]` is predictable for exercises like `ft_print_program_name`.
+pub fn run_program(
+    subject: &ProgramSubject,
+    source_files: &[PathBuf],
+) -> anyhow::Result<CheckResult> {
+    let tmp = tempfile::TempDir::new()?;
+    let binary = tmp.path().join("a.out");
+
+    let compile_out = Command::new("cc")
+        .args([
+            "-Wall",
+            "-Wextra",
+            "-Werror",
+            "-fsanitize=address,undefined",
+            "-g",
+        ])
+        .args(source_files)
+        .arg("-o")
+        .arg(&binary)
+        .output()?;
+
+    if !compile_out.status.success() {
+        let msgs: Vec<String> = String::from_utf8_lossy(&compile_out.stderr)
+            .lines()
+            .map(String::from)
+            .collect();
+        return Ok(CheckResult::fail("Program tests (compile)", msgs));
+    }
+
+    let asan_opts = if cfg!(target_os = "linux") {
+        "detect_leaks=1:log_path=/dev/stderr"
+    } else {
+        "log_path=/dev/stderr"
+    };
+
+    let mut msgs: Vec<String> = Vec::new();
+    let mut pass_count = 0usize;
+
+    for tc in subject.tests {
+        let run_out = Command::new("./a.out")
+            .current_dir(tmp.path())
+            .args(tc.argv)
+            .env("ASAN_OPTIONS", asan_opts)
+            .env("UBSAN_OPTIONS", "print_stacktrace=1")
+            .output()?;
+
+        let stderr_text = String::from_utf8_lossy(&run_out.stderr);
+        let asan_errors: Vec<String> = stderr_text
+            .lines()
+            .filter(|l| l.contains("ERROR") || l.contains("runtime error"))
+            .map(String::from)
+            .collect();
+
+        if !asan_errors.is_empty() {
+            msgs.push(format!("  FAIL  {} — ASAN/UBSAN error", tc.name));
+            msgs.extend(asan_errors);
+            continue;
+        }
+
+        let hash = Sha256::digest(&run_out.stdout);
+        if hash.as_slice() == tc.expected_sha256.as_slice() {
+            pass_count += 1;
+            msgs.push(format!("  PASS  {}", tc.name));
+        } else {
+            msgs.push(format!("  FAIL  {}", tc.name));
+        }
+    }
+
+    let all_pass = msgs.iter().all(|l| l.trim_start().starts_with("PASS"));
+    if all_pass && pass_count > 0 {
+        Ok(CheckResult::pass(format!(
+            "Program tests ({pass_count} passed)"
+        )))
+    } else {
+        Ok(CheckResult::fail("Program tests", msgs))
     }
 }
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use crate::checks::{compiler, harness, valgrind};
 use crate::config::Config;
 use crate::report::{CheckResult, SuiteResult};
-use crate::subjects::Subject;
+use crate::subjects::{ProgramSubject, Subject};
 
 /// Resolve every required source file inside *exercise_dir*.
 /// Returns `None` (with the list of missing files) if any are absent.
@@ -114,6 +114,97 @@ pub fn run(subject: &Subject, exercise_dir: &Path, cfg: &Config) -> SuiteResult 
     SuiteResult {
         exercise: subject.exercise.to_string(),
         function: subject.function.to_string(),
+        checks,
+    }
+}
+
+/// Locate source files for a program-based subject.
+pub fn locate_program_files(
+    subject: &ProgramSubject,
+    exercise_dir: &Path,
+) -> Result<Vec<PathBuf>, Vec<String>> {
+    let mut paths = Vec::new();
+    let mut missing = Vec::new();
+    for &file in subject.files {
+        let p = exercise_dir.join(file);
+        if p.exists() {
+            paths.push(p);
+        } else {
+            missing.push(format!("missing: {file}"));
+        }
+    }
+    if missing.is_empty() {
+        Ok(paths)
+    } else {
+        Err(missing)
+    }
+}
+
+/// Run the full check suite for a program-based subject (C06-style).
+///
+/// Skips the symbol check and function harness — uses `harness::run_program`
+/// instead, which compiles the student binary and spawns it with test argv.
+pub fn run_program(subject: &ProgramSubject, exercise_dir: &Path, cfg: &Config) -> SuiteResult {
+    let mut checks: Vec<CheckResult> = Vec::new();
+
+    let source_files = match locate_program_files(subject, exercise_dir) {
+        Ok(f) => f,
+        Err(missing) => {
+            checks.push(CheckResult::fail("Files present", missing));
+            return SuiteResult {
+                exercise: subject.exercise.to_string(),
+                function: subject.program.to_string(),
+                checks,
+            };
+        }
+    };
+    let source_paths: Vec<&Path> = source_files.iter().map(PathBuf::as_path).collect();
+
+    checks.push(CheckResult::skip(
+        "Symbol check",
+        "not applicable for program-based exercises",
+    ));
+
+    // Build with ASAN/UBSAN
+    let tmp = match tempfile::TempDir::new() {
+        Ok(t) => t,
+        Err(e) => {
+            checks.push(CheckResult::error("Build", e.to_string()));
+            return SuiteResult {
+                exercise: subject.exercise.to_string(),
+                function: subject.program.to_string(),
+                checks,
+            };
+        }
+    };
+
+    let sanitize = !cfg.checks.no_sanitizers;
+    let binary = tmp.path().join("student_bin");
+    let build_res = compiler::compile(&source_paths, &binary, sanitize);
+    let build_ok = build_res.is_pass();
+    checks.push(build_res);
+
+    if build_ok && !cfg.checks.no_valgrind {
+        checks.push(valgrind::check(&binary, std::time::Duration::from_secs(10)));
+    }
+
+    if build_ok {
+        if subject.tests.is_empty() {
+            checks.push(CheckResult::skip(
+                "Program tests",
+                "no test vectors defined for this subject",
+            ));
+        } else {
+            match harness::run_program(subject, &source_files) {
+                Ok(r) => checks.push(r),
+                Err(e) => checks.push(CheckResult::error("Program tests", e.to_string())),
+            }
+        }
+    }
+
+    SuiteResult {
+        exercise: subject.exercise.to_string(),
+        function: subject.program.to_string(),
         checks,
     }
 }

--- a/src/subjects/c06.rs
+++ b/src/subjects/c06.rs
@@ -1,0 +1,137 @@
+//! C06 subject definitions — program-based exercises (argc/argv).
+//!
+//! Each `ProgramTestCase.expected_sha256` is a SHA-256 commitment of
+//! the expected stdout bytes.  The program is compiled to `./a.out`
+//! and invoked with `argv` in a temp directory so that `argv[0]` is
+//! always `"./a.out"`.
+//!
+//! To verify a commitment: `printf 'expected' | sha256sum`.
+
+use hex_literal::hex;
+
+use super::{ProgramSubject, ProgramTestCase};
+
+pub static ALL: &[ProgramSubject] = &[
+    // ── ex00 ───────────────────────────────────────────────────────
+    ProgramSubject {
+        exercise: "ex00",
+        program: "ft_print_program_name",
+        files: &["ft_print_program_name.c"],
+        description: "Display the program name followed by a newline.",
+        tests: &[ProgramTestCase {
+            name: "no extra args",
+            argv: &[],
+            // printf './a.out\n' | sha256sum
+            expected_sha256: &hex!(
+                "761420cd18b7cf45d6a8d2c373ca7b6d22b988d063dcd208a9a14d7b7bc16f85"
+            ),
+        }],
+    },
+    // ── ex01 ───────────────────────────────────────────────────────
+    ProgramSubject {
+        exercise: "ex01",
+        program: "ft_print_params",
+        files: &["ft_print_params.c"],
+        description: "Display all arguments (except argv[0]) in order, one per line.",
+        tests: &[
+            ProgramTestCase {
+                name: "no args",
+                argv: &[],
+                // printf '' | sha256sum
+                expected_sha256: &hex!(
+                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                ),
+            },
+            ProgramTestCase {
+                name: "test1 test2 test3",
+                argv: &["test1", "test2", "test3"],
+                // printf 'test1\ntest2\ntest3\n' | sha256sum
+                expected_sha256: &hex!(
+                    "bb673e7722bc7453f4de9da7694966f178ac572c73331cec30335e04562aad21"
+                ),
+            },
+            ProgramTestCase {
+                name: "42",
+                argv: &["42"],
+                // printf '42\n' | sha256sum
+                expected_sha256: &hex!(
+                    "084c799cd551dd1d8d5c5f9a5d593b2e931f5e36122ee5c793c1d08a19839cc0"
+                ),
+            },
+        ],
+    },
+    // ── ex02 ───────────────────────────────────────────────────────
+    ProgramSubject {
+        exercise: "ex02",
+        program: "ft_rev_params",
+        files: &["ft_rev_params.c"],
+        description: "Display all arguments (except argv[0]) in reverse order, one per line.",
+        tests: &[
+            ProgramTestCase {
+                name: "no args",
+                argv: &[],
+                // printf '' | sha256sum
+                expected_sha256: &hex!(
+                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                ),
+            },
+            ProgramTestCase {
+                name: "test1 test2 test3",
+                argv: &["test1", "test2", "test3"],
+                // printf 'test3\ntest2\ntest1\n' | sha256sum
+                expected_sha256: &hex!(
+                    "0887820b086a438e410d4f80d60f69a978b9d4d1a646130e3b9e2a5373771fa9"
+                ),
+            },
+            ProgramTestCase {
+                name: "hello",
+                argv: &["hello"],
+                // printf 'hello\n' | sha256sum
+                expected_sha256: &hex!(
+                    "5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03"
+                ),
+            },
+        ],
+    },
+    // ── ex03 ───────────────────────────────────────────────────────
+    ProgramSubject {
+        exercise: "ex03",
+        program: "ft_sort_params",
+        files: &["ft_sort_params.c"],
+        description: "Display all arguments (except argv[0]) sorted in ASCII order, one per line.",
+        tests: &[
+            ProgramTestCase {
+                name: "no args",
+                argv: &[],
+                // printf '' | sha256sum
+                expected_sha256: &hex!(
+                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                ),
+            },
+            ProgramTestCase {
+                name: "banana apple cherry",
+                argv: &["banana", "apple", "cherry"],
+                // printf 'apple\nbanana\ncherry\n' | sha256sum
+                expected_sha256: &hex!(
+                    "6883ada0490e1bd845b6032e95119d522212f98b840eef466ebb09f4a9eb7a03"
+                ),
+            },
+            ProgramTestCase {
+                name: "def abc (reverse input)",
+                argv: &["def", "abc"],
+                // printf 'abc\ndef\n' | sha256sum
+                expected_sha256: &hex!(
+                    "924d391c158a46409fdff363063d718ea0bc00b14556f129984942af91233bbe"
+                ),
+            },
+            ProgramTestCase {
+                name: "A B C (already sorted)",
+                argv: &["A", "B", "C"],
+                // printf 'A\nB\nC\n' | sha256sum
+                expected_sha256: &hex!(
+                    "706204f15ce1834ad298c8e8d270315652bbd6e40cec489f65802db2fdd03167"
+                ),
+            },
+        ],
+    },
+];

--- a/src/subjects/mod.rs
+++ b/src/subjects/mod.rs
@@ -4,6 +4,7 @@
 //! generate the C test harness and run every check.
 
 pub mod c00;
+pub mod c06;
 pub mod rush00;
 
 /// A single test case for a C function.
@@ -49,4 +50,38 @@ pub fn all_c00() -> &'static [Subject] {
 /// All Rush00 subjects, in order.
 pub fn all_rush() -> &'static [Subject] {
     rush00::ALL
+}
+
+// ── Program-based subjects (argc/argv, student provides main) ──────
+
+/// A single test case for a program that receives command-line arguments.
+pub struct ProgramTestCase {
+    /// Human-readable label shown in PASS/FAIL output.
+    pub name: &'static str,
+    /// Arguments passed after `argv[0]` (`./a.out`).
+    /// Empty slice means the program is invoked with no extra args.
+    pub argv: &'static [&'static str],
+    /// SHA-256 commitment of the expected stdout bytes.
+    ///
+    /// Computed with `printf 'expected' | sha256sum`.
+    pub expected_sha256: &'static [u8; 32],
+}
+
+/// One 42-school piscine exercise whose entry point is `main`.
+pub struct ProgramSubject {
+    /// Folder name, e.g. `"ex00"`.
+    pub exercise: &'static str,
+    /// Program name, e.g. `"ft_print_program_name"`.
+    pub program: &'static str,
+    /// Source files the student must provide (relative to exercise dir).
+    pub files: &'static [&'static str],
+    /// One-line description shown in the TUI and boomer CLI.
+    pub description: &'static str,
+    /// Test vectors for the program runner.
+    pub tests: &'static [ProgramTestCase],
+}
+
+/// All C06 subjects, in order.
+pub fn all_c06() -> &'static [ProgramSubject] {
+    c06::ALL
 }


### PR DESCRIPTION
Closes #69

## Summary

- Introduces `ProgramTestCase` / `ProgramSubject` parallel to the
  existing function-based `TestCase` / `Subject` — no existing subjects
  are touched
- `harness::run_program()` compiles student source to `./a.out` in a
  temp dir and spawns it once per test with fixed `argv`; ASAN/UBSAN
  enabled; stdout SHA-256 hashed against stored commitments
- `eval::run_program()` dispatches the full check suite (build →
  valgrind → program tests) for program-based subjects; symbol check is
  explicitly skipped with a clear reason
- `subjects/c06.rs` covers all four C06 exercises (ex00–ex03) with
  deterministic SHA-256 test vectors
- `fuzz_c06_compiler` fuzz target asserts `compiler::compile` never
  panics on arbitrary C program source

## Test plan

- [ ] `cargo check` — clean
- [ ] `cargo clippy -- -D warnings` — zero warnings
- [ ] `cargo test` — all existing tests pass
- [ ] Manual: run `dawon` against a correct C06 student directory and
  confirm PASS for all four exercises
- [ ] Manual: run `dawon` against a stub C06 directory and confirm FAIL
- [ ] Fuzz (nightly): `cargo +nightly fuzz run fuzz_c06_compiler`

🤖 Generated with [Claude Code](https://claude.com/claude-code)